### PR TITLE
Изменения в прогрессивных метриках

### DIFF
--- a/dictionary.md
+++ b/dictionary.md
@@ -879,14 +879,18 @@
 **прогрессивные веб-метрики,** набор метрик страницы, связанных с [быстродействием](#performance).
 
 - first paint — **первая отрисовка**
-- first contentful paint — **первая существенная отрисовка**
+- first contentful paint (FCP) — **первая существенная отрисовка**
 - first meaningful paint — **первая значимая отрисовка**
 - visually ready — **визуальная готовность**
 - visually complete — **визуальная завершённость**
 - first interactive — **первая интерактивность**
 - estimated input latency — **ожидаемая задержка ввода**
-- time to first interactive — **время до первой интерактивности**
-- time to first consistently interactive — **время до начала стабильной интерактивности**
+- time to interactive (TTI) — **время до первой интерактивности**
+- time to first consistently interactive — **время до стабильной интерактивности**
+- largest contentful paint (LCP) — **наибольшая существенная отрисовка**
+- cumulative layout shift (CLS) — **совокупное изменение раскладки**
+- total blocking time (TBT) — **время полной блокировки основного потока**
+- first input delay (FID) — **время отклика на первую интерактивность**
 
 ### prolyfill
 

--- a/dictionary.md
+++ b/dictionary.md
@@ -889,8 +889,8 @@
 - time to first consistently interactive — **время до стабильной интерактивности**
 - largest contentful paint (LCP) — **наибольшая существенная отрисовка**
 - cumulative layout shift (CLS) — **совокупное изменение раскладки**
-- total blocking time (TBT) — **время полной блокировки основного потока**
-- first input delay (FID) — **время отклика на первую интерактивность**
+- total blocking time (TBT) — **суммарное время блокировки**
+- first input delay (FID) — **время отклика на первое взаимодействие**
 
 ### prolyfill
 


### PR DESCRIPTION
Добавляет изменения в формулировки прогрессивных метрик + добавляет 4 новых.

Некоторые метрики даются с труом :) Нужна помощь.

1. По аналогии с **время до первой интерактивности** я убрал слово _начало_ из **время до стабильной интерактивности**
2. Добавлены аббревиатуры для метрик. Из **time to interactive** убран _first_, но в переводе я пока его оставил
3. Список метрик, предложенный в статье, отличается, от [принятого на данный момент](https://web.dev/user-centric-performance-metrics/#important-metrics-to-measure). Есть ли смысл убрать некоторые из метрик? Имхо можно и оставить.
4. По поводу перевода свежих метрик у меня есть вопросы к своему же переводу :)
По FID — я использовал сочетание _время отклика_ как замену слова _задержка_, поскольку _задержка ввода_ присутствует в переводе фразы _input latency_.
По CLS — есть устоявшийся перевод слова _shift_ как _сдвиг_. Но, как мне кажется, раскладка на странице не двигается. Двигаться могут элементы раскладки, так ведь?
По TBT — решил добавить блокировки «чего». В [расширенном определении](https://web.dev/user-centric-performance-metrics/#types-of-metrics) указывается, что блокировка между FCP и TTI, возможно стоит добавить в описание