### PR TITLE
Добавляет Miriam Suzanne

### DIFF
--- a/names.md
+++ b/names.md
@@ -370,6 +370,10 @@
 
 **Сáттон, Марси** — [marcysutton.com](https://marcysutton.com/), [@marcysutton](https://twitter.com/marcysutton)
 
+### Suzanne, Miriam
+
+**Сюзанн, Мириам** — [miriamsuzanne.com](https://www.miriamsuzanne.com/), [@mirisuzanne](https://twitter.com/MiriSuzanne)
+
 ## U
 
 ### Ubl, Malte


### PR DESCRIPTION
Насчёт Мириам примерно понятно, делать Мириэм как-то не принято.

По аналогии Сюзанн вместо Сюзэнн. [Здесь можно послушать](https://youtu.be/uwgBz748t-g?t=59) как она представляется.

Точно не Сьюзен, фамилия именно на французский манер.