### PR TITLE
Добавлен термин "производные цвета" (relative colors)

### DIFF
--- a/dictionary.md
+++ b/dictionary.md
@@ -1042,7 +1042,7 @@
 
 ### relative colors
 
-**производные цвета**, изменение цвета, встроенное в CSS, напр. _added OKLCH relative color syntax example — добавлен пример синтаксиса производного цвета в OKLCH._ [Появляются](https://www.w3.org/TR/css-color-5/#:~:text=The%20new%20relative%20color%20syntax,possibly%20modified%20with%20math%20functions) в спецификации CSS Color Module Level 5.
+**производные цвета**, изменение цвета, встроенное в CSS, напр. _added OKLCH relative color syntax example — добавлен пример синтаксиса производного цвета в OKLCH._ Появляются в спецификации [CSS Color Module Level 5](https://www.w3.org/TR/css-color-5/#:~:text=The%20new%20relative%20color%20syntax,possibly%20modified%20with%20math%20functions).
 
 ### rem
 

--- a/dictionary.md
+++ b/dictionary.md
@@ -852,6 +852,10 @@
 
 **непрозрачный,** степень непрозрачности, напр. _opaque by 75% — непрозрачен на 75%,_ значит прозрачность 25%.
 
+### origin colors
+
+**начальные цвета**, цвета до применения к ним встроенных в CSS изменений (см. [relative colors](#relative-colors)).
+
 ### outline
 
 **обводка,** внешний равномерный контур элемента, не участвующий в блочной модели.
@@ -1038,7 +1042,7 @@
 
 ### relative colors
 
-**производные цвета**, изменение цвета, встроенное в CSS. [Появляется](https://www.w3.org/TR/css-color-5/#:~:text=The%20new%20relative%20color%20syntax,possibly%20modified%20with%20math%20functions) в спецификации [CSS Color Module Level 5](https://www.w3.org/TR/css-color-5/).
+**производные цвета**, изменение цвета, встроенное в CSS, напр. _added OKLCH relative color syntax example — добавлен пример синтаксиса производного цвета в OKLCH._ [Появляются](https://www.w3.org/TR/css-color-5/#:~:text=The%20new%20relative%20color%20syntax,possibly%20modified%20with%20math%20functions) в спецификации CSS Color Module Level 5.
 
 ### rem
 

--- a/dictionary.md
+++ b/dictionary.md
@@ -1036,6 +1036,10 @@
 
 **перекомпоновка**
 
+### relative colors
+
+**производные цвета**, изменение цвета, встроенное в CSS. [Появляется](https://www.w3.org/TR/css-color-5/#:~:text=The%20new%20relative%20color%20syntax,possibly%20modified%20with%20math%20functions) в спецификации [CSS Color Module Level 5](https://www.w3.org/TR/css-color-5/).
+
 ### rem
 
 **рем,** единица измерения в CSS, которая зависит от размера шрифта корневого элемента `<html>`, напр. _font-size: 3rem — размер шрифта 3 рема._


### PR DESCRIPTION
В процессе работы над переводом статьи, где фигурирует спецификация [CSS Color Module Level 5](https://www.w3.org/TR/css-color-5/), возникла потребность перевести термин **relative colors**.
Перевод "относительные цвета" (как и "взаимосвязанные", "сравнительные") кажется не столь правильным и содержательным, как "производные".

Термин **производные цвета** поможет понять, что эти цвета появляются в процессе изменения существующих цветов.