### PR TITLE
Правит транслитерацию фамилий

### DIFF
--- a/names.md
+++ b/names.md
@@ -58,7 +58,7 @@
 
 ### Comeau, Josh
 
-**Камю, Джош** — [joshwcomeau.com](https://joshwcomeau.com), [@joshwcomeau](https://twitter.com/joshwcomeau)
+**Комо́, Джош** — [joshwcomeau.com](https://joshwcomeau.com), [@joshwcomeau](https://twitter.com/joshwcomeau)
 
 ### Coyier, Chris
 
@@ -254,7 +254,7 @@
 
 ### Meyer, Eric
 
-**Мейер, Эрик** — [meyerweb.com](https://meyerweb.com), [@meyerweb](https://twitter.com/meyerweb)
+**Ма́йер, Эрик** — [meyerweb.com](https://meyerweb.com), [@meyerweb](https://twitter.com/meyerweb)
 
 ### Meurer, Benedikt
 


### PR DESCRIPTION
PR правит некорректную транслитерацию некоторых фамилий.

## Eric Meyer: Мейер → Майер

Meyer — фамилия немецкого происхождения, по правилам немецкой орфографии читается /ˈmaɪ̯ɐ/. Диграф *ey* по правилам [немецко-русской практической транскрипции](https://ru.wikipedia.org/wiki/Немецко-русская_практическая_транскрипция) также передаётся как *ай*.

Аудиоподтверждение можно найти, например, в начале [этого видео](https://www.youtube.com/watch?v=UsDyC6fSxIM).

## Josh Comeau: Камю → Комо

Comeau — фамилия французского происхождения, по правилам французской орфографии читается /kɔˈmo/. Камю (Camus) — другая фамилия, которая принадлежала, например, философу Альберу Камю.

По правилам [французско-русской практической транскрипции](https://ru.wikipedia.org/wiki/Французско-русская_практическая_транскрипция) как графема *o*, так и триграф *eau* передаются как *о*.

С аудиоподтверждением в данном случае ситуация сложнее, поскольку Джош представитель англоязычной культуры, а на английском языке Comeau произносится со своими особенностями (с дифтонгом во втором слоге, а в разных региональных вариантах возможна и разная постановка ударения): /ˈkɒməʊ/, /kəˈmoʊ/. Как пример есть [такое видео](https://www.youtube.com/watch?v=mGEvJzL_NHM). Тем не менее на написание это не влияет.